### PR TITLE
Update build, documentation, and lcow package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,21 +21,18 @@ jobs:
           name: Fetch binaries
           command: |
             curl -fsSL -o /tmp/docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz
-            curl -fsSL -o /work/bin/linuxkit https://152-46932243-gh.circle-artifacts.com/0/linuxkit-linux-amd64
-            curl -fsSL -o /work/bin/moby https://309-89286561-gh.circle-artifacts.com/0/moby-linux
+            curl -fsSL -o /work/bin/linuxkit https://196-46932243-gh.circle-artifacts.com/0/linuxkit-linux-amd64
             tar xfO /tmp/docker.tgz docker/docker > /work/bin/docker
             sha256sum /work/bin/*
             sha256sum -c <<EOF
             6af40e74b2dbb2927882acab52d50bfc72551779d541957fc70b6adc325ee5ef  /work/bin/docker
-            ae8355a9bb3cf8197c8c9b1afec1e53622e0e40b2680736bc4f45565c7aea1b9  /work/bin/linuxkit
-            eb1df021470bc9f528ae2c55c4a802cb34e8935fa130be90bf9b147a39ec4822  /work/bin/moby
+            908d1e149680a2ad2f5fbf4cd5e1c2bbf7ab4a4394de773a93e25dc6d234d426 /work/bin/linuxkit
             EOF
       - run:
           name: Versions
           command: |
-            chmod +x /work/bin/linuxkit && /work/bin/linuxkit version
-            chmod +x /work/bin/moby && /work/bin/moby version
             chmod +x /work/bin/docker && /work/bin/docker version
+            chmod +x /work/bin/linuxkit && /work/bin/linuxkit version
       - run:
           name: Build
           command: make release && mv release.zip /work/out

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 build: lcow.yml Makefile
-	moby build lcow.yml
+	linuxkit build lcow.yml
 	mv lcow-kernel bootx64.efi
 	mv lcow-initrd.img initrd.img
 bootx64.efi: build
@@ -12,7 +12,6 @@ release.zip: bootx64.efi initrd.img versions.txt
 	zip $@ bootx64.efi initrd.img versions.txt
 
 versions.txt:
-	moby version > $@
 	linuxkit version >> $@
 	git rev-list -1 HEAD >> $@
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LinuxKit based LCOW images
 
+[![CircleCI](https://circleci.com/gh/linuxkit/lcow.svg?style=svg)](https://circleci.com/gh/linuxkit/lcow)
+
 This repository hosts the components to build a LinuxKit based Linux
 image for Linux Containers on Windows.
 
@@ -68,24 +70,20 @@ package is called [`init-lcow`](./pkg/init-lcow).
 
 ### Prerequisites
 
-To build images you will need the [Moby
-tool](https://github.com/moby/tool), and to rebuild the individual
-packages you will need the [LinuxKit
+To build images and packages you will need the [LinuxKit
 tool](https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit). You
 also need to have a working Docker installation.
 
 If you already have `go` installed you can use `go get -u
-github.com/moby/tool/cmd/moby` to install the `moby` build tool, and
-`go get -u github.com/linuxkit/linuxkit/src/cmd/linuxkit` to install
-the `linuxkit` tool.
+github.com/linuxkit/linuxkit/src/cmd/linuxkit` to install the
+`linuxkit` tool.
 
 On macOS there is a `brew tap` available. Detailed instructions are at
 [linuxkit/homebrew-linuxkit](https://github.com/linuxkit/homebrew-linuxkit),
-the short summary is
+but the short summary is:
 
 ```
 brew tap linuxkit/linuxkit
-brew install --HEAD moby
 brew install --HEAD linuxkit
 ```
 
@@ -104,7 +102,7 @@ which generates `bootx64.efi` and `initrd.img` which need to be copied to `"$env
 Alternatively, use:
 
 ```
-moby build lcow.yml
+linuxkit build lcow.yml
 ```
 
 This will generate three files: `lcow-kernel`, `lcow-initrd.img`, and

--- a/lcow.yml
+++ b/lcow.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:4d345747495255b10d5ed91e06f241ab3a1204dd
+  - linuxkit/init-lcow:c9b7c2ca7d2ddaae9eb78dde265e2f14ac0d9f29
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 files:
   - path: etc/linuxkit.yml

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:7d79062909882186e881aad263668d66e6df2a28 AS mirror
+FROM linuxkit/alpine:585174df463ba33e6c0e2050a29a0d9e942d56cb AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -7,9 +7,9 @@ RUN apk add --no-cache --initdb -p /out \
     musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:7d79062909882186e881aad263668d66e6df2a28 AS build
+FROM linuxkit/alpine:585174df463ba33e6c0e2050a29a0d9e942d56cb AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
-ENV OPENGCS_COMMIT=2a3a94cca366171f159399ffbd1333058e1cef53
+ENV OPENGCS_COMMIT=ec7c21720ed6d773a98dfa29a8f2f292b879c05f
 RUN apk add --no-cache build-base curl git go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN git clone $OPENGCS_REPO /go/src/github.com/Microsoft/opengcs && \


### PR DESCRIPTION
- Use `linuxkit build` instead of `moby build`
- Update documentation to remove `moby` as dependency (and add Circle CI badge)
- Super minor update to the lcow package and image while at it