### PR TITLE
Assorted updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,12 @@ jobs:
           name: Fetch binaries
           command: |
             curl -fsSL -o /tmp/docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz
-            curl -fsSL -o /work/bin/linuxkit https://196-46932243-gh.circle-artifacts.com/0/linuxkit-linux-amd64
+            curl -fsSL -o /work/bin/linuxkit             https://521-46932243-gh.circle-artifacts.com/0/linuxkit-linux-amd64
             tar xfO /tmp/docker.tgz docker/docker > /work/bin/docker
             sha256sum /work/bin/*
             sha256sum -c <<EOF
             6af40e74b2dbb2927882acab52d50bfc72551779d541957fc70b6adc325ee5ef  /work/bin/docker
-            908d1e149680a2ad2f5fbf4cd5e1c2bbf7ab4a4394de773a93e25dc6d234d426 /work/bin/linuxkit
+            f3fe26a44d8662af29d0ee7bc1213464692a47308b076e60b183ec6244786697  /work/bin/linuxkit
             EOF
       - run:
           name: Versions

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ rm release.zip
 
 ### Run
 
+On recent `docker` master builds (`master-dockerproject-2018-01-20, build 44a1168a` or newer):
+
+Start the docker daemon (in an elevated PowerShell):
+
+```
+.\dockerd.exe -D --experimental
+```
+
+You should now be able to run Linux containers on Windows, e.g.:
+
+```
+docker run --platform linux --rm -ti busybox sh
+```
+
+On older `docker` master builds:
+
 Start the docker daemon (in an elevated PowerShell):
 
 ```

--- a/lcow.yml
+++ b/lcow.yml
@@ -4,7 +4,7 @@ kernel:
   tar: none
 init:
   - linuxkit/init-lcow:ee8a280abdad079922eeaf70af295d8e4905c3a5
-  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/lcow.yml
+++ b/lcow.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:c9b7c2ca7d2ddaae9eb78dde265e2f14ac0d9f29
+  - linuxkit/init-lcow:ee8a280abdad079922eeaf70af295d8e4905c3a5
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 files:
   - path: etc/linuxkit.yml

--- a/lcow.yml
+++ b/lcow.yml
@@ -1,6 +1,5 @@
 kernel:
-  # XXX Use the content hash as there are several 4.12.14 images on hub
-  image: linuxkit/kernel:4.12.14-c4d19a4de21def5a5134a6f70ef7212c31104bf1
+  image: linuxkit/kernel:4.14.14
   cmdline: "console=ttyS0"
   tar: none
 init:

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 FROM linuxkit/alpine:585174df463ba33e6c0e2050a29a0d9e942d56cb AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
-ENV OPENGCS_COMMIT=ec7c21720ed6d773a98dfa29a8f2f292b879c05f
+ENV OPENGCS_COMMIT=v0.3.5
 RUN apk add --no-cache build-base curl git go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN git clone $OPENGCS_REPO /go/src/github.com/Microsoft/opengcs && \


### PR DESCRIPTION
- Use latest `linuxkit` in CI
- Switch to 4.14.14 kernel. The 4.12 kernel used previously is outdated and has security issues. 4.14.14 still has some known issue around Hyper-V sockets (https://github.com/linuxkit/linuxkit/issues/2724) but they likely also existed in the 4.12 kernel.
- Update OpenGCS to v0.3.5
- Update `runc` to latest used in LinuxKit
- Update documentation with recent `moby/moby` changes (https://github.com/moby/moby/pull/36065 and https://github.com/moby/moby/pull/34859).
