### PR TITLE
Update kernel to 4.14.29

### DIFF
--- a/lcow.yml
+++ b/lcow.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
   tar: none
 init:


### PR DESCRIPTION
This LinuxKit kernel has some storevsc_drv (Hyper-V SCSI frontend)
patches backported which may help with the hot-unplug issues
we have seen in LCOW global mode.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

/cc @jhowardmsft and @jterry75