### PR TITLE
tests: Fix root where tests are stored

### DIFF
--- a/tests/cases/900_perf/100_hostvol/020_single_dir/040_stat_touch_5000_files/test.ps1
+++ b/tests/cases/900_perf/100_hostvol/020_single_dir/040_stat_touch_5000_files/test.ps1
@@ -8,7 +8,7 @@ $lib = Join-Path -Path $libBase -ChildPath lib.ps1
 
 $ret = 0
 
-$testPath = $env:TEST_TMP_ROOT
+$testPath = $env:TEST_TMP
 Remove-Item -Force -Recurse -ErrorAction Ignore -Path $testPath
 New-Item -ItemType Directory -Force -Path $testPath
 $i = 0


### PR DESCRIPTION
With 077fa7f737c0 ("tests: Convert many files benchmarks to
use rtf benchmarks") I missed one test where the base directory
the temporary files needed updating. This commit fixes this.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>