### PR TITLE
Update OpenGCS

### DIFF
--- a/lcow.yml
+++ b/lcow.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:0f819e9c533d06d8da9674fd43ba967cae096dfb
+  - linuxkit/init-lcow:8290a43cddaae9125b729b11a672e28d27597ab6
   - linuxkit/runc:v0.4
 files:
   - path: etc/linuxkit.yml

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
-ENV OPENGCS_COMMIT=f5289606ba2d62e2c7d9aa73ec87353622d98a09
+ENV OPENGCS_COMMIT=f4421ed6d06d1583e4625634a8cc4f5f864d77fe
 RUN apk add --no-cache build-base curl git go linux-headers musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN git clone $OPENGCS_REPO /go/src/github.com/Microsoft/opengcs && \

--- a/tests/RunTests.ps1
+++ b/tests/RunTests.ps1
@@ -51,7 +51,7 @@ if ( !(Test-Path .\bin\docker-compose.exe) ) {
     Invoke-WebRequest -UseBasicParsing -OutFile bin\docker-compose.exe "https://github.com/docker/compose/releases/download/$composeRelease/docker-compose-Windows-x86_64.exe"
 }
 
-$rtfBuildNumber = 60
+$rtfBuildNumber = 69
 if ( !(Test-Path .\bin\rtf.exe) ) {
     Invoke-WebRequest -UseBasicParsing -OutFile bin\rtf.exe "https://$rtfBuildNumber-89472225-gh.circle-artifacts.com/0/rtf-windows-amd64.exe"
 }


### PR DESCRIPTION
This picks up https://github.com/Microsoft/opengcs/pull/237 which fixes https://github.com/Microsoft/opengcs/issues/234 and https://github.com/Microsoft/opengcs/issues/236 which cause `docker run` to return an error even if the run succeeded.

While at it also use a newer `rtf` build to run tests