### PR TITLE
Update components and rename 'bootx86.efi' to 'kernel'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *-kernel
 *-cmdline
 *-state
+/kernel
 versions.txt
 /tests/_results
 /tests/bin

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .PHONY: build
 build: lcow.yml Makefile
 	linuxkit build lcow.yml
-	mv lcow-kernel bootx64.efi
+	mv lcow-kernel kernel
 	mv lcow-initrd.img initrd.img
-bootx64.efi: build
+kernel: build
 initrd.img: build
 
 .PHONY: release
 release: release.zip
-release.zip: bootx64.efi initrd.img versions.txt
-	zip $@ bootx64.efi initrd.img versions.txt
+release.zip: kernel initrd.img versions.txt
+	zip $@ kernel initrd.img versions.txt
 
 versions.txt:
 	linuxkit version >> $@

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Simply type:
 make
 ```
 
-which generates `bootx64.efi` and `initrd.img` which need to be copied to `"$env:ProgramFiles\Linux Containers\bootx64.efi"` on your Windows system.
+which generates `kernel` and `initrd.img` which need to be copied to `"$env:ProgramFiles\Linux Containers\kernel"` on your Windows system.
 
 
 Alternatively, use:
@@ -131,7 +131,7 @@ linuxkit build lcow.yml
 
 This will generate three files: `lcow-kernel`, `lcow-initrd.img`, and
 `lcow-cmdline`. `lcow-kernel` needs to be copied to
-`"$env:ProgramFiles\Linux Containers\bootx64.efi"` and
+`"$env:ProgramFiles\Linux Containers\kernel"` and
 `lcow-initrd.img` to `"$env:ProgramFiles\Linux
 Containers\initrd.img"`.
 

--- a/lcow.yml
+++ b/lcow.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:8290a43cddaae9125b729b11a672e28d27597ab6
-  - linuxkit/runc:v0.4
+  - linuxkit/init-lcow:0b6d22dcead2548c4ba8761f0fccb728553ebd06
+  - linuxkit/runc:v0.5
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/lcow.yml
+++ b/lcow.yml
@@ -1,5 +1,6 @@
 kernel:
-  image: linuxkit/kernel:4.14.53
+  # For now use an older kernel. See https://github.com/linuxkit/linuxkit/issues/3120
+  image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
   tar: none
 init:

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
-ENV OPENGCS_COMMIT=f4421ed6d06d1583e4625634a8cc4f5f864d77fe
+ENV OPENGCS_COMMIT=2398de591e9c577c112c6eeb7dd7659ecc77a46e
 RUN apk add --no-cache build-base curl git go linux-headers musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN git clone $OPENGCS_REPO /go/src/github.com/Microsoft/opengcs && \

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:8a89682421abf0d886d777235a05f4a04a736df2 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -7,7 +7,7 @@ RUN apk add --no-cache --initdb -p /out \
     musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:8a89682421abf0d886d777235a05f4a04a736df2 AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
 ENV OPENGCS_COMMIT=2398de591e9c577c112c6eeb7dd7659ecc77a46e
 RUN apk add --no-cache build-base curl git go linux-headers musl-dev

--- a/tests/RunTests.ps1
+++ b/tests/RunTests.ps1
@@ -12,7 +12,7 @@ if ( $args.Count -eq 1 ) {
     Expand-Archive release.zip -DestinationPath "$Env:ProgramFiles\Linux Containers\."
     Remove-Item release.zip
 } else {
-    if ( !(Test-Path ..\lcow-kernel) -and !(Test-Path ..\bootx64.efi) ) {
+    if ( !(Test-Path ..\lcow-kernel) -and !(Test-Path ..\kernel) ) {
         Write-Output "Could not find kernel"
         exit 1
     }
@@ -22,9 +22,9 @@ if ( $args.Count -eq 1 ) {
     }
     mkdir "$env:ProgramFiles\Linux Containers"
     if ( Test-Path ..\lcow-kernel ) {
-        Copy-Item ..\lcow-kernel "$env:ProgramFiles\Linux Containers\bootx64.efi"
+        Copy-Item ..\lcow-kernel "$env:ProgramFiles\Linux Containers\kernel"
     } else {
-        Copy-Item ..\bootx64.efi "$env:ProgramFiles\Linux Containers\bootx64.efi"        
+        Copy-Item ..\kernel "$env:ProgramFiles\Linux Containers\kernel"
     }
     if ( Test-Path ..\lcow-initrd.img ) {
         Copy-Item ..\lcow-initrd.img "$env:ProgramFiles\Linux Containers\initrd.img"


### PR DESCRIPTION
Normal update of all the components. Also the latest master build of `moby/moby` now expects the kernel to be called `kernel` instead of `bootx86.efi` (see https://github.com/moby/moby/pull/37515)