### PR TITLE
(maint) Remove note about old kernel

### DIFF
--- a/lcow.yml
+++ b/lcow.yml
@@ -1,5 +1,4 @@
 kernel:
-  # For now use an older kernel. See https://github.com/linuxkit/linuxkit/issues/3120
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
   tar: none


### PR DESCRIPTION
 - #41 bumped the kernel to 4.19.27, and #37 already noted that the
   performance concerns over kernel version (and slow pulls) were no
   longer relevant.

   Therefore, remove the note.